### PR TITLE
Fix and optimize Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+.github
+lib

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-FROM node:alpine
+FROM node:16-alpine
 
 LABEL maintainer=rob9315
 LABEL name=2b2wTS
 
 WORKDIR /srv/app
 
-COPY . /srv/app
-
 RUN apk add --no-cache git;\
-npm install;\
 apk del --no-cache git || true
+
+COPY . /srv/app
+RUN npm install
 
 EXPOSE 8080/tcp
 EXPOSE 25565/tcp


### PR DESCRIPTION
There is no .dockerignore file so when building the image docker also transfers the node_modules folder. You don't want to do that in most cases. This also puts the git install before the npm install and the copy command so that this stage can be reused when rebuilding after changing files making the build process faster. There seams to also be an error when installing some dependencies due to the node.js version installed by the node:alpine image is currently 18. I capped it to the latest LTS version of 16 to make it more reliable with most dependencies.